### PR TITLE
Support "group" attribute and user belongs to not-same name gid.

### DIFF
--- a/lib/itamae/plugin/resource/authorized_keys.rb
+++ b/lib/itamae/plugin/resource/authorized_keys.rb
@@ -85,12 +85,12 @@ module Itamae
           attributes.content = ssh_keys
           attributes.mode    = "0600"
           attributes.owner   = attributes.username
-          attributes.group   = attributes.username
+          attributes.group   = run_specinfra(:get_user_gid, attributes.username).stdout.strip if attributes.group.nil?
           attributes.path    = keys_path
 
           attributes.dir_mode  = "0700"
           attributes.dir_owner = attributes.username
-          attributes.dir_group = attributes.username
+          attributes.dir_group = attributes.group
         end
 
         def source_file


### PR DESCRIPTION
itamae-plugin-resource-authorized_keys support only for users
belong to same-name gid. (ex: user1:wheel)

This patch allow these users and "group" attribute.
## Test case

```
# Test case for itamae-plugin-resource-authorized_keys
require 'itamae/plugin/resource/authorized_keys'

uid1 = 'testuser1'
uid2 = 'testuser2'

# Case 1: User belongs to group diffrent from username.
user 'Create user' do
  action :create
  username uid1
  gid 'wheel'
  create_home true
end

# if uid: testuser and gid: wheel, failed at here.
authorized_keys uid1 do
  owner uid1
  content "sample fake ssh-key\n"
end

# Case 2: authorized_keys with "group" attribute.
user 'Create user' do
  action :create
  username uid2
  create_home true
end
authorized_keys uid2 do
  owner uid2
  group 'wheel'
  content "sample fake ssh-key\n"
end
```
